### PR TITLE
Don't overwrite LD_LIBRARY_PATH variable

### DIFF
--- a/coinbrew
+++ b/coinbrew
@@ -1158,7 +1158,7 @@ function build_proj {
            ([ $run_tests = "main" ] && [ x$main_proj != x ] && [ $main_proj_dir = $dir ]); then
         print_action "Running $dir unit test"
         # Fix for systems where the unit test doesn't seem to run with specifying LD_LIBRARY_PATH
-        export LD_LIBRARY_PATH=$prefix/lib
+        export LD_LIBRARY_PATH=$prefix/lib:$LD_LIBRARY_PATH
         if [ $verbosity -ge 2 ]; then
             if [ x$main_proj != x ] && [ $main_proj_dir = $dir ]; then
                 invoke_make $((verbosity+1)) test


### PR DESCRIPTION
Breaking people's preexisting setup is easily avoided by appending to LD_LIBRARY_PATH instead of overwriting it.
In my case, I have my OpenBLAS install in /opt/OpenBLAS and have the linker point to there using the LD_LIBRAY_PATH variable sourced in my .profile, and this caused the unit tests at the end to fail because they couldn't find the shared library files.